### PR TITLE
thread delegate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(CMakeEventSystem LANGUAGES CXX)
 
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 0)
-set(VERSION_PATCH 1)
+set(VERSION_PATCH 2)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)

--- a/src/EventSystem.hpp
+++ b/src/EventSystem.hpp
@@ -43,7 +43,7 @@ public:
         } else {
           try {
             del->template exec<void, EventListener, VArgs...>(vargs...);
-          } catch (const std::bad_function_call& e) {
+          } catch (const bad_delegate_call& e) {
             Log().error("Exception caught in \"{}\": {}", _name, e.what());
             succ = false;
           }

--- a/src/Exceptions.hpp
+++ b/src/Exceptions.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <exception>
+#include <string>
+
+class bad_delegate_call : public std::exception {
+public:
+  bad_delegate_call(const char* msg)
+    : _message(msg) {
+  }
+  const char* what() const throw()
+  {
+    return _message.c_str();
+  }
+private:
+  std::string _message;
+};

--- a/src/GDelegate.hpp
+++ b/src/GDelegate.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Exceptions.hpp"
+
 #include <typeinfo>
 
 /// @brief Generic member function Delegate for storage and explicit variadic execution.
@@ -42,7 +44,7 @@ public:
     TReturn(TObj::* func)(const VArgs&...) = reinterpret_cast<TReturn(TObj::*)(const VArgs&...)>(_func);
     // Ensure the types of vargs match those expected by the underlying VDelegate
     if (_typeHashCode != typeid(func).hash_code()) {
-      throw std::bad_function_call();
+      throw bad_delegate_call("GDelegate: Run-time type-safety check failed. Ensure execution function signature matches underlying member function signature.");
     }
     return (objPtr->*func)(vargs...);
   }

--- a/src/TDelegate.hpp
+++ b/src/TDelegate.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "Exceptions.hpp"
+#include "GDelegate.hpp"
+
+/// @brief Variadic member function Delegate that can store arguments and execute at a later time on another thread.
+/// @tparam TReturn Delegate return type.
+/// @tparam TObj Object pointer type.
+/// @tparam ...VArgs Parameter pack.
+template<class TReturn, class TObj, class... VArgs>
+class TDelegate {
+public:
+  TDelegate(const TObj* objPtr, TReturn(TObj::* func)(const VArgs&...))
+    : _objPtr(const_cast<TObj*>(objPtr))
+    , _func(func)
+    , _primed(false)
+    , _params() {
+  }
+
+  TDelegate(const TDelegate& other)
+    : _objPtr(other._objPtr)
+    , _func(other._func)
+    , _primed(other._primed)
+    , _params(other._params) {
+  }
+
+  TDelegate(const TDelegate&& other) {
+    _objPtr = other._objPtr;
+    _func = other._func;
+    _primed = other._primed;
+    _params = other._params;
+
+    other._objPtr = nullptr;
+    other._func = nullptr;
+    other._primed = false;
+    other._params = std::tuple<VArgs...>();
+  }
+
+  TDelegate& operator=(const TDelegate& other) {
+    _objPtr = other._objPtr;
+    _func = other._func;
+    _primed = other._primed;
+    return *this;
+  }
+
+  bool isPrimed() {
+    return _primed;
+  }
+
+  void prime(const VArgs&... vargs) {
+    _primed = true;
+    _params = std::make_tuple(vargs...);
+  }
+
+  /// @brief Executes the Delegate.
+  /// @param ...vargs Arguments passed to the method pointer.
+  /// @return Return value of the method pointer.
+  TReturn exec() {
+    if (!_primed)
+      throw bad_delegate_call("Execution attempted on a TDelegate that was not primed.");
+    _primed = false;
+    return std::apply(std::bind_front(_func, _objPtr), _params);
+  }
+
+  /// @brief Executes the Delegate.
+  /// @param ...vargs Arguments passed to the method pointer.
+  /// @return Return value of the method pointer.
+  TReturn operator()() {
+    return exec();
+  }
+
+  /// @brief Equals operator.
+  /// @param other Other instance to compare to.
+  /// @return True if both objPtr and func are the same, false otherwise.
+  bool operator==(const TDelegate<TReturn, TObj, VArgs...>& other) const {
+    return _objPtr == other._objPtr &&  _func == other._func;
+  }
+
+  /// @brief Not-equals operator.
+  /// @param other Other instance to compare to.
+  /// @return True if objPtr or func are NOT the same, false otherwise.
+  bool operator!=(const TDelegate<TReturn, TObj, VArgs...>& other) const {
+    return _objPtr != other._objPtr || _func != other._func;
+  }
+
+  /// @brief Checks if this Delegate calls the incoming instance.
+  /// @param caller Instance to check ownership against.
+  /// @return True if the Delegate references the provided caller.
+  bool isCaller(const TObj* caller) const {
+    return _objPtr == caller;
+  }
+
+private:
+  TObj* _objPtr;
+  TReturn(TObj::* _func)(const VArgs&...);
+  std::atomic_bool _primed;
+  std::tuple<VArgs...> _params;
+};

--- a/src/TDelegate.hpp
+++ b/src/TDelegate.hpp
@@ -43,10 +43,14 @@ public:
     return *this;
   }
 
+  /// @brief Checks if the delegate is primed for execution.
+  /// @return True if delegate is primed, otherwise False.
   bool isPrimed() {
     return _primed;
   }
 
+  /// @brief Primes the delegate storing arguments for later execution.
+  /// @param ...vargs Arguments passed to the method pointer.
   void prime(const VArgs&... vargs) {
     _primed = true;
     _params = std::make_tuple(vargs...);
@@ -63,7 +67,6 @@ public:
   }
 
   /// @brief Executes the Delegate.
-  /// @param ...vargs Arguments passed to the method pointer.
   /// @return Return value of the method pointer.
   TReturn operator()() {
     return exec();

--- a/test/src/Events_DelegateTest.cpp
+++ b/test/src/Events_DelegateTest.cpp
@@ -1,10 +1,11 @@
 #include "gtest/gtest.h"
 #include "ADelegate.hpp"
 #include "VDelegate.hpp"
+#include "TDelegate.hpp"
 
-class MemberClass {
+class ExampleClass {
 public:
-  MemberClass() {
+  ExampleClass() {
     _data = 0;
   }
   void setData(const int& data) {
@@ -38,69 +39,96 @@ protected:
 
   void TearDown() override {
   };
-  MemberClass _class;
+  ExampleClass _class;
 };
 
 TEST_F(Events_DelegateTest, VDelegateExecute) {
-  VDelegate<int, MemberClass> delGetData(&_class, &MemberClass::getData);
+  VDelegate<int, ExampleClass> delGetData(&_class, &ExampleClass::getData);
 
   // no parameter
-  VDelegate<void, MemberClass> delSetOne(&_class, &MemberClass::setOne);
+  VDelegate<void, ExampleClass> delSetOne(&_class, &ExampleClass::setOne);
   delSetOne();
   EXPECT_EQ(1, delGetData());
   _class.setData(0);
 
   // multiple parameters
-  VDelegate<void, MemberClass, int, int> delAdd(&_class, &MemberClass::setAdd);
+  VDelegate<void, ExampleClass, int, int> delAdd(&_class, &ExampleClass::setAdd);
   int num = 5;
   delAdd(num, num);
   EXPECT_EQ(num * 2, delGetData());
 }
 
-TEST_F(Events_DelegateTest, GDelegateTypeSafety) {
-  VDelegate<int, MemberClass> a(&_class, &MemberClass::getData);
-  GDelegate genDel = a.asGeneric();
-
-  // Note: Macros don't like templates because the comma parses as another macro arg.
-  // Adding extra '()' around our statement encapsulates it.
-  EXPECT_NO_THROW((genDel.exec<int, MemberClass>()));
-  EXPECT_THROW((genDel.exec<long int, MemberClass>()), std::bad_function_call);
-  EXPECT_THROW((genDel.exec<int, MemberClass, int>(0)), std::bad_function_call);
-}
-
 TEST_F(Events_DelegateTest, VDelegateGenericConversion) {
-  VDelegate<int, MemberClass> a(&_class, &MemberClass::getData);
+  VDelegate<int, ExampleClass> a(&_class, &ExampleClass::getData);
   GDelegate genDel = a.asGeneric();
 
   _class.setData(1);
-  int rtn = genDel.exec<int, MemberClass>();
+  int rtn = genDel.exec<int, ExampleClass>();
   EXPECT_EQ(1, rtn);
 }
 
 TEST_F(Events_DelegateTest, ADelegateExecute) {
-  ADelegate<MemberClass, int> delegate;
-  delegate.add(&_class, &MemberClass::add);
+  ADelegate<ExampleClass, int> delegate;
+  delegate.add(&_class, &ExampleClass::add);
   delegate(2);
   EXPECT_EQ(2, _class.getData());
 }
 
 TEST_F(Events_DelegateTest, ADelegateMultiExecuteInOrder) {
-  ADelegate<MemberClass, int> delegate;
+  ADelegate<ExampleClass, int> delegate;
   // _data += 2;
-  delegate.add(&_class, &MemberClass::add);
+  delegate.add(&_class, &ExampleClass::add);
   // _data *= 2;
-  delegate.add(&_class, &MemberClass::multiply);
+  delegate.add(&_class, &ExampleClass::multiply);
   // _data = 0;
   // _data += 2; -> 2;
   // _data *= 2; -> 4;
   delegate(2);
   EXPECT_EQ(4, _class.getData());
 
-  delegate.remove(&_class, &MemberClass::multiply);
+  delegate.remove(&_class, &ExampleClass::multiply);
   delegate(2);
   EXPECT_EQ(6, _class.getData());
 
-  delegate.remove(&_class, &MemberClass::add);
+  delegate.remove(&_class, &ExampleClass::add);
   delegate(2);
   EXPECT_EQ(6, _class.getData());
+}
+
+TEST_F(Events_DelegateTest, GDelegateTypeSafety) {
+  VDelegate<int, ExampleClass> a(&_class, &ExampleClass::getData);
+  GDelegate genDel = a.asGeneric();
+
+  // Note: Macros don't like templates because the comma parses as another macro arg.
+  // Adding extra '()' around our statement encapsulates it.
+  EXPECT_NO_THROW((genDel.exec<int, ExampleClass>()));
+  EXPECT_THROW((genDel.exec<long int, ExampleClass>()), bad_delegate_call);
+  EXPECT_THROW((genDel.exec<int, ExampleClass, int>(0)), bad_delegate_call);
+}
+
+TEST_F(Events_DelegateTest, TDelegatePrimeAndExecute) {
+  // Test priming the delegate and then executing it
+  TDelegate<void, ExampleClass, int, int> threadDelegate(&_class, &ExampleClass::setAdd);
+  threadDelegate.prime(5, 3); // prime with arguments 5 and 3
+  EXPECT_NO_THROW(threadDelegate()); // execute the delegate
+  EXPECT_EQ(_class.getData(), 8); // check if data is set correctly
+}
+
+TEST_F(Events_DelegateTest, TDelegateExecuteWithoutPrime) {
+  // Test executing a primed delegate without priming it first
+  TDelegate<void, ExampleClass, int, int> threadDelegate(&_class, &ExampleClass::setAdd);
+  EXPECT_THROW(threadDelegate(), bad_delegate_call); // should throw because not primed
+}
+
+TEST_F(Events_DelegateTest, TDelegateEquality) {
+  // Test equality operator for delegates
+
+  TDelegate<void, ExampleClass, int> delegate1(&_class, &ExampleClass::add);
+  TDelegate<void, ExampleClass, int> delegate2(&_class, &ExampleClass::add);
+  TDelegate<void, ExampleClass, int> delegate3(&_class, &ExampleClass::multiply);
+  EXPECT_TRUE(delegate1 == delegate2); // delegates should be equal
+  EXPECT_TRUE(delegate1 != delegate3); // delegates should not be equal
+
+  EXPECT_FALSE(delegate1 != delegate2); // delegates should be equal
+  EXPECT_FALSE(delegate1 == delegate3); // delegates should not be equal
 }


### PR DESCRIPTION
Thread Delegates

- A thread-safe variadic member function Delegate that stores arguments to execute at a later time on another thread
- Added tests for TDelegate
- added bad_delegate_call exception
